### PR TITLE
fix: support inline tables

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -17,3 +17,5 @@ jobs:
         uses: nvim-neorocks/luarocks-tag-release@v5
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          test_interpreters: ""

--- a/spec/toml_edit_spec.lua
+++ b/spec/toml_edit_spec.lua
@@ -8,6 +8,35 @@ describe("toml-edit", function()
         local result = toml_edit.parse(toml_content)
         assert.equal("1.0.0", result.rocks["toml-edit"])
     end)
+    it("Can read from table", function()
+        local toml_content = [[
+          [rocks.neorg]
+          version = "1.0.0"
+          opt = true
+        ]]
+        local result = toml_edit.parse(toml_content)
+        local rock = result.rocks.neorg
+        assert.equal("1.0.0", rock.version)
+        assert.equal(true, rock.opt)
+    end)
+    it("Can read from inline table", function()
+        local toml_content = [[
+          [rocks]
+          "toml-edit" = { version = "1.0.0", opt = true }
+        ]]
+        local result = toml_edit.parse(toml_content)
+        local rock = result.rocks["toml-edit"]
+        assert.equal("1.0.0", rock.version)
+        assert.equal(true, rock.opt)
+    end)
+    it("Preserves inline tables", function()
+        local toml_content = [[
+          [rocks]
+          "toml-edit" = { version = "1.0.0", opt = true }
+        ]]
+        local result = toml_edit.parse(toml_content)
+        assert.equal(toml_content, tostring(result))
+    end)
     it("Can set value", function()
         local toml_content = [[
           [rocks]
@@ -27,6 +56,55 @@ describe("toml-edit", function()
         local result = toml_edit.parse(toml_content)
         result.rocks["toml-edit"] = "1.0.0"
         local expected = toml_content:format("1.0.0")
+        assert.equal(expected, tostring(result))
+    end)
+    it("Can set value in table", function()
+        local toml_content = [[
+          [rocks.neorg]
+          version = "%s"
+        ]]
+        local result = toml_edit.parse(toml_content)
+        local rock = result.rocks.neorg
+        rock.version = "2.0.0"
+        local expected = toml_content:format("2.0.0")
+        assert.equal(expected, tostring(result))
+    end)
+    it("Can add value to table", function()
+        local toml_content = [[
+[rocks.neorg]
+version = "1.0.0"
+]]
+        local result = toml_edit.parse(toml_content)
+        local rock = result.rocks.neorg
+        rock.opt = false
+        local expected = [[
+[rocks.neorg]
+version = "1.0.0"
+opt = false
+]]
+        assert.equal(expected, tostring(result))
+    end)
+    it("Preserves inline tables when setting a value", function()
+        local toml_content = [[
+[rocks]
+"toml-edit" = { version = "%s" }
+]]
+        local result = toml_edit.parse(toml_content)
+        result.rocks["toml-edit"].version = "2.0.0"
+        local expected = toml_content:format("2.0.0")
+        assert.equal(expected, tostring(result))
+    end)
+    it("Preserves inline tables when adding a new value", function()
+        local toml_content = [[
+[rocks]
+"toml-edit" = { version = "1.0.0" }
+]]
+        local result = toml_edit.parse(toml_content)
+        result.rocks["toml-edit"].opt = true
+        local expected = [[
+[rocks]
+"toml-edit" = { version = "1.0.0" , opt = true }
+]]
         assert.equal(expected, tostring(result))
     end)
 end)


### PR DESCRIPTION
This is a follow-up to #6.

This PR:

- Adds (get + set) support for inline tables, such as `neorg = { version = "1.0.0", opt = true }`
- Adds some more test cases.
- Replaces `todo!()` macros with `RuntimeError`s, so that the error messages in lua have a stack trace and make it clear where the error is coming from.

With this fix, we can also address https://github.com/nvim-neorocks/rocks.nvim/issues/96.

As I can't base my branch on that PR, this PR currently contains the changes for both PRs.
After a rebase, when #6 is merged, the diff will be smaller :smile: 