### PR TITLE
feat: don't depend on luarocks-build-rust-mlua

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+build:
+ifeq ($(findstring "/5.1",$(INST_LIBDIR)),)
+			cargo build --release --features lua51
+else ifeq ($(findstring "/5.2",$(INST_LIBDIR)),)
+			cargo build --release --features lua52
+else ifeq ($(findstring "/5.3",$(INST_LIBDIR)),)
+			cargo build --release --features lua53
+else ifeq ($(findstring "/5.4",$(INST_LIBDIR)),)
+			cargo build --release --features lua54
+endif
+
+install:
+	mkdir -p $(INST_LIBDIR)
+	@if [ -f target/release/libtoml_edit.so ]; then cp target/release/libtoml_edit.so $(INST_LIBDIR)/toml_edit.so; fi
+	@if [ -f target/release/libtoml_edit.dylib ]; then cp target/release/libtoml_edit.dylib $(INST_LIBDIR)/toml_edit.dylib; fi
+	@if [ -f target/release/libtoml_edit.dll ]; then cp target/release/libtoml_edit.dll $(INST_LIBDIR)/toml_edit.dll; fi

--- a/README.md
+++ b/README.md
@@ -36,9 +36,5 @@ luarocks make --tree=luarocks
 luarocks test
 ```
 
-> [!NOTE]
->
-> You may need to `luarocks install --local luarocks-build-rust-mlua`.
-
 [luarocks-shield]: https://img.shields.io/luarocks/v/neorg/toml-edit?logo=lua&color=purple&style=for-the-badge
 [luarocks-url]: https://luarocks.org/modules/neorg/toml-edit

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -8,7 +8,6 @@
       };
       nativeCheckInputs = with luaself;
         [
-          luarocks-build-rust-mlua
           busted
         ]
         ++ oa.nativeCheckInputs;

--- a/toml-edit-dev-1.rockspec
+++ b/toml-edit-dev-1.rockspec
@@ -11,17 +11,16 @@ description = {
 
 dependencies = {
     "lua >= 5.1",
-    "luarocks-build-rust-mlua",
 }
 
 test_dependencies = {
     "lua >= 5.1",
-    "luarocks-build-rust-mlua",
 }
 
 build = {
-    type = "rust-mlua",
-    modules = {
-        "toml_edit"
+    type = "make",
+    install_variables = {
+      INST_PREFIX='$(PREFIX)',
+      INST_LIBDIR='$(LIBDIR)',
     },
 }


### PR DESCRIPTION
This uses a Makefile instead.
Using `luarocks-build-rust-mlua` has some downsides:

- Users have to install it (this seems to cause problems on some systems), even if they are pulling the binary rock. This is because luarocks doesn't have a separate `build_dependencies` table.
- On the GitHub Actions Windows runner, luarocks fails to build this with `luarocks-build-rust-mlua`. I don't know if this is an issue for Windows in general, but this might fix it.