### PR TITLE
fix: set package name in luarocks.yml

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
+          name: toml-edit
           test_interpreters: ""
           summary: "TOML Parser + Formatting and Comment-Preserving Editor"
           detailed_description: |


### PR DESCRIPTION
The luarocks workflow picks up `toml-edit.lua` as the package name.