### PR TITLE
fix: fix Darwin compilation

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,11 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,3 @@ mlua = { version = "0.9.6", features = ["module", "serialize"] }
 serde = "1.0"
 toml_edit = "0.22.9"
 toml = "0.8.12"
-
-[target.x86_64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-
-[target.aarch64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]


### PR DESCRIPTION
Addresses #27 

Adding target configurations to ./.cargo/config, instead of ./Cargo.toml fixes the issues with compilation on Darwin.

Fixes compilation errors like the ones [found in nixpkgs](https://hydra.nixos.org/build/256372059/log)

`nix flake check -L` passed successfully.