### PR TITLE
feat: add `parse_spanned` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use mlua::{ExternalError, Lua, LuaSerdeExt, Result, Value};
 use std::cell::RefCell;
 use std::rc::Rc;
-use toml_edit::{value, DocumentMut, ImDocument, Key};
+use toml_edit::{DocumentMut, ImDocument, Key};
 
 // TODO: Better error messages
 
@@ -247,7 +247,7 @@ pub fn toml_edit(lua: &'static Lua) -> Result<mlua::Table> {
                                         name: Some("selector".into()),
                                         cause: format!(
                                             "array '{}' does not have a value at index {}. The full path that was provided: {}",
-                                            key.to_string(),
+                                            key,
                                             num,
                                             path.to_str().unwrap()
                                         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-use mlua::{ExternalError, Lua, LuaSerdeExt, Result};
+use mlua::{ExternalError, Lua, LuaSerdeExt, Result, Value};
 use std::cell::RefCell;
 use std::rc::Rc;
-use toml_edit::DocumentMut;
+use toml_edit::{value, DocumentMut, ImDocument, Key};
 
 // TODO: Better error messages
 
@@ -50,7 +50,7 @@ where
                     table.set("__path", path)?;
                     table.set_metatable(Some(mt_clone.clone()));
 
-                    Ok(mlua::Value::Table(table))
+                    Ok(Value::Table(table))
                 }
                 toml_edit::Item::Value(value) => match value {
                     toml_edit::Value::String(str) => lua.to_value(&str.value()),
@@ -61,7 +61,7 @@ where
                         let table = lua.create_table()?;
                         table.set("__path", path)?;
                         table.set_metatable(Some(mt_clone.clone()));
-                        Ok(mlua::Value::Table(table))
+                        Ok(Value::Table(table))
                     }
                     _ => Err(mlua::Error::RuntimeError(format!(
                         "toml-edit: cannot parse {}: {} yet",
@@ -69,7 +69,7 @@ where
                         value
                     ))),
                 },
-                toml_edit::Item::None => Ok(mlua::Value::Nil),
+                toml_edit::Item::None => Ok(Value::Nil),
                 item => Err(mlua::Error::RuntimeError(format!(
                     "toml-edit: cannot parse: '{}'",
                     item
@@ -82,7 +82,7 @@ where
     metatable.set(
         "__newindex",
         lua.create_function(
-            move |_, (tbl, key, value): (mlua::Table, mlua::String, mlua::Value)| {
+            move |_, (tbl, key, value): (mlua::Table, mlua::String, Value)| {
                 let mut path = tbl.get::<_, Vec<String>>("__path")?;
                 path.push(key.to_str()?.to_string());
 
@@ -108,16 +108,16 @@ where
                         });
 
                 *entry = match value {
-                    mlua::Value::Nil => toml_edit::Item::None,
-                    mlua::Value::String(str) => toml_edit::value(str.to_str()?.to_string()),
-                    mlua::Value::Number(number) => toml_edit::value(
-                        lua.from_value::<mlua::Number>(mlua::Value::Number(number))?,
-                    ),
-                    mlua::Value::Integer(int) => toml_edit::value(
-                        lua.from_value::<mlua::Integer>(mlua::Value::Integer(int))?,
-                    ),
-                    mlua::Value::Boolean(bool) => toml_edit::value(bool),
-                    mlua::Value::Table(_table) => {
+                    Value::Nil => toml_edit::Item::None,
+                    Value::String(str) => toml_edit::value(str.to_str()?.to_string()),
+                    Value::Number(number) => {
+                        toml_edit::value(lua.from_value::<mlua::Number>(Value::Number(number))?)
+                    }
+                    Value::Integer(int) => {
+                        toml_edit::value(lua.from_value::<mlua::Integer>(Value::Integer(int))?)
+                    }
+                    Value::Boolean(bool) => toml_edit::value(bool),
+                    Value::Table(_table) => {
                         // Update state data within Lua
                         // for pair in tbl.pairs() {
                         //     let (key, value): (mlua::Value, mlua::Value) = pair?;
@@ -148,7 +148,7 @@ where
         lua.create_function(move |lua, ()| lua.to_value(&document.borrow().to_string()))?,
     )?;
 
-    table.set_metatable(Some(metatable));
+    table.set_metatable(Some(metatable.clone()));
 
     Ok(table)
 }
@@ -176,6 +176,106 @@ pub fn toml_edit(lua: &'static Lua) -> Result<mlua::Table> {
             };
 
             lua.to_value(&tbl)
+        })?,
+    )?;
+    table.set(
+        "parse_spanned",
+        lua.create_function(move |lua: &Lua, str: mlua::String| {
+            let spanned = lua.create_table()?;
+
+            let document: ImDocument<String> = match str.to_string_lossy().parse() {
+                Ok(document) => document,
+                Err(err) => return Err(err.into_lua_err()),
+            };
+
+            spanned.set(
+                "span_of",
+                lua.create_function(
+                    move |lua: &Lua, (path, selector): (mlua::String, Value)| {
+                        let initial_key = Key::new("");
+
+                        let (key, item) = path.to_str().unwrap().split('.').try_fold(
+                            (&initial_key, document.as_item()),
+                            |acc: (&Key, &toml_edit::Item), next_path| {
+                                acc.1.as_table().unwrap().get_key_value(next_path).ok_or(
+                                    mlua::Error::BadArgument {
+                                        to: Some("span_of".into()),
+                                        pos: 1,
+                                        name: Some("path".into()),
+                                        cause: format!(
+                                            "key '{}' does not exist in the TOML. The full path that was provided: {}",
+                                            next_path,
+                                            path.to_str().unwrap()
+                                        )
+                                        .into_lua_err()
+                                        .into(),
+                                    },
+                                )
+                            },
+                        )?;
+
+                        match selector {
+                            Value::String(str) if str == "key" => Ok(key
+                                .span()
+                                .map(|val| lua.to_value(&val).unwrap())
+                                .unwrap_or(Value::Nil)),
+                            Value::String(str) if str == "value" => Ok(item
+                                .span()
+                                .map(|val| lua.to_value(&val).unwrap())
+                                .unwrap_or(Value::Nil)),
+                            Value::Integer(num) => Ok(
+                                item
+                                .as_array()
+                                .ok_or(
+                                    mlua::Error::BadArgument {
+                                        to: Some("span_of".into()),
+                                        pos: 2,
+                                        name: Some("selector".into()),
+                                        cause: format!(
+                                            "value {} is not an array (required for numerical selectors)",
+                                            path.to_str().unwrap()
+                                        )
+                                        .into_lua_err()
+                                        .into(),
+                                    }
+                                )?
+                                .get(num as usize)
+                                .ok_or(
+                                    mlua::Error::BadArgument {
+                                        to: Some("span_of".into()),
+                                        pos: 2,
+                                        name: Some("selector".into()),
+                                        cause: format!(
+                                            "array '{}' does not have a value at index {}. The full path that was provided: {}",
+                                            key.to_string(),
+                                            num,
+                                            path.to_str().unwrap()
+                                        )
+                                        .into_lua_err()
+                                        .into(),
+                                    }
+                                )?
+                                .span()
+                                .map(|val| lua.to_value(&val).unwrap())
+                                .unwrap_or(Value::Nil)),
+                            _ => {
+                                Err(
+                                    mlua::Error::BadArgument {
+                                        to: Some("span_of".into()),
+                                        pos: 2,
+                                        name: Some("selector".into()),
+                                        cause: r#"expected one of: "key", "value" or a number"#
+                                            .into_lua_err()
+                                            .into(),
+                                    },
+                                )
+                            }
+                        }
+                    },
+                )?,
+            )?;
+
+            Ok(spanned)
         })?,
     )?;
     Ok(table)


### PR DESCRIPTION
This PR adds a parse_spanned function that parses a document with span information. A span_of function can then be used to query the span of a key or value of a given object in the TOML.